### PR TITLE
Document sample output for SBLGNT inspection helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - Keep code changes **minimal, modular, and easy to test**.
 - Ensure **automated tests cover new or modified logic**; rely on the CI pipeline to enforce coverage.
 - Prefer adding focused unit or integration tests alongside code changes.
+- When documenting commands that are not executed by CI, include example output captured from an actual run.
 
 ## Text & Analysis Requirements
 - For any textual or analytical output, **double-check conclusions and supporting evidence** before presenting them.

--- a/docs/sblgnt-data-access.md
+++ b/docs/sblgnt-data-access.md
@@ -87,4 +87,93 @@ The SBLGNT source does **not** contain clause segmentations or IDs. Future claus
 - The textual apparatus under `external-data/SBLGNT/data/sblgntapp` mirrors the verse structure and can be parsed in the same fashion; each `<note>` conveys a textual variant for the preceding `<verse>` tag.
 - The plain-text files in `external-data/SBLGNT/data/sblgnt/text` are convenient for quick manual inspection or diffing, but they do not expose the token-level metadata found in the XML.
 
+## Quick text inspection helper
+
+For rapid sanity checks without opening a notebook, use `scripts/inspect_sblgnt.py`. The script lists the available books and prints verses from either corpus with optional filters. The examples below show real output captured from the helper:
+
+```bash
+$ python scripts/inspect_sblgnt.py --list-books
+1Cor
+1John
+1Pet
+1Thess
+1Tim
+2Cor
+2John
+2Pet
+2Thess
+2Tim
+3John
+Acts
+Col
+Eph
+Gal
+Heb
+Jas
+John
+Jude
+Luke
+Mark
+Matt
+Phil
+Phlm
+Rev
+Rom
+Titus
+sblgnt
+```
+
+The trailing `sblgnt` entry represents the aggregated corpus file that the upstream project ships alongside the per-book texts.
+
+```bash
+$ python scripts/inspect_sblgnt.py --book Mark --limit 5
+Mark 1:1: Ἀρχὴ τοῦ εὐαγγελίου Ἰησοῦ ⸀χριστοῦ.
+Mark 1:2: ⸀Καθὼς γέγραπται ἐν ⸂τῷ Ἠσαΐᾳ τῷ προφήτῃ⸃·  ⸀Ἰδοὺ ἀποστέλλω τὸν ἄγγελόν μου
+          πρὸ προσώπου σου, ὃς κατασκευάσει τὴν ὁδόν ⸀σου·
+Mark 1:3: φωνὴ βοῶντος ἐν τῇ ἐρήμῳ· Ἑτοιμάσατε τὴν ὁδὸν κυρίου, εὐθείας ποιεῖτε τὰς
+          τρίβους αὐτοῦ,
+Mark 1:4: ἐγένετο Ἰωάννης ⸀ὁ βαπτίζων ἐν τῇ ⸀ἐρήμῳ κηρύσσων βάπτισμα μετανοίας εἰς
+          ἄφεσιν ἁμαρτιῶν.
+Mark 1:5: καὶ ἐξεπορεύετο πρὸς αὐτὸν πᾶσα ἡ Ἰουδαία χώρα καὶ οἱ Ἱεροσολυμῖται ⸂πάντες,
+          καὶ ἐβαπτίζοντο⸃  ⸂ὑπʼ αὐτοῦ ἐν τῷ Ἰορδάνῃ ποταμῷ⸃ ἐξομολογούμενοι τὰς
+          ἁμαρτίας αὐτῶν.
+```
+
+```bash
+$ python scripts/inspect_sblgnt.py --book Mark --source text --limit 5
+ΚΑΤΑ ΜΑΡΚΟΝ
+Mark 1:1: Ἀρχὴ τοῦ εὐαγγελίου Ἰησοῦ ⸀χριστοῦ.
+Mark 1:2: ⸀Καθὼς γέγραπται ἐν ⸂τῷ Ἠσαΐᾳ τῷ προφήτῃ⸃· ⸀Ἰδοὺ ἀποστέλλω τὸν ἄγγελόν μου πρὸ
+          προσώπου σου, ὃς κατασκευάσει τὴν ὁδόν ⸀σου·
+Mark 1:3: φωνὴ βοῶντος ἐν τῇ ἐρήμῳ· Ἑτοιμάσατε τὴν ὁδὸν κυρίου, εὐθείας ποιεῖτε τὰς
+          τρίβους αὐτοῦ,
+Mark 1:4: ἐγένετο Ἰωάννης ⸀ὁ βαπτίζων ἐν τῇ ⸀ἐρήμῳ κηρύσσων βάπτισμα μετανοίας εἰς
+          ἄφεσιν ἁμαρτιῶν.
+```
+
+```bash
+$ python scripts/inspect_sblgnt.py --book Luke --contains "Ἰησοῦ" --limit 10
+Luke 1:31: καὶ ἰδοὺ συλλήμψῃ ἐν γαστρὶ καὶ τέξῃ υἱόν, καὶ καλέσεις τὸ ὄνομα αὐτοῦ
+           Ἰησοῦν.
+Luke 2:21: Καὶ ὅτε ἐπλήσθησαν ἡμέραι ὀκτὼ τοῦ περιτεμεῖν αὐτόν, καὶ ἐκλήθη τὸ ὄνομα
+           αὐτοῦ Ἰησοῦς, τὸ κληθὲν ὑπὸ τοῦ ἀγγέλου πρὸ τοῦ συλλημφθῆναι αὐτὸν ἐν τῇ
+           κοιλίᾳ.
+Luke 2:27: καὶ ἦλθεν ἐν τῷ πνεύματι εἰς τὸ ἱερόν· καὶ ἐν τῷ εἰσαγαγεῖν τοὺς γονεῖς τὸ
+           παιδίον Ἰησοῦν τοῦ ποιῆσαι αὐτοὺς κατὰ τὸ εἰθισμένον τοῦ νόμου περὶ αὐτοῦ
+Luke 2:43: καὶ τελειωσάντων τὰς ἡμέρας, ἐν τῷ ὑποστρέφειν αὐτοὺς ὑπέμεινεν Ἰησοῦς ὁ παῖς
+           ἐν Ἰερουσαλήμ, καὶ οὐκ ⸂ἔγνωσαν οἱ γονεῖς⸃ αὐτοῦ.
+Luke 2:52: Καὶ Ἰησοῦς προέκοπτεν ⸂σοφίᾳ καὶ ἡλικίᾳ⸃ καὶ χάριτι παρὰ θεῷ καὶ ἀνθρώποις.
+Luke 3:21: Ἐγένετο δὲ ἐν τῷ βαπτισθῆναι ἅπαντα τὸν λαὸν καὶ Ἰησοῦ βαπτισθέντος καὶ
+           προσευχομένου ἀνεῳχθῆναι τὸν οὐρανὸν
+Luke 3:23: Καὶ αὐτὸς ⸀ἦν Ἰησοῦς ⸂ἀρχόμενος ὡσεὶ ἐτῶν τριάκοντα⸃, ὢν ⸂υἱός, ὡς
+           ἐνομίζετο⸃, Ἰωσὴφ τοῦ Ἠλὶ
+Luke 3:29: τοῦ ⸀Ἰησοῦ τοῦ Ἐλιέζερ τοῦ Ἰωρὶμ τοῦ Μαθθὰτ τοῦ Λευὶ
+Luke 4:1: Ἰησοῦς δὲ ⸂πλήρης πνεύματος ἁγίου⸃ ὑπέστρεψεν ἀπὸ τοῦ Ἰορδάνου, καὶ ἤγετο ἐν
+          τῷ πνεύματι ⸂ἐν τῇ ἐρήμῳ⸃
+Luke 4:4: καὶ ἀπεκρίθη ⸂πρὸς αὐτὸν ὁ Ἰησοῦς⸃· Γέγραπται ὅτι Οὐκ ἐπʼ ἄρτῳ μόνῳ ζήσεται ⸀ὁ
+          ⸀ἄνθρωπος.
+```
+
+Use `--show-paragraphs` to include paragraph indices derived from the XML structure in the output; this makes it easy to verify paragraph transitions while reviewing the text.
+
 These notes provide the baseline needed for the next tasks (scripts, viewer prototype, clause schema decisions) to consume the SBLGNT corpus consistently.

--- a/plans/gospel-of-mark-plan.md
+++ b/plans/gospel-of-mark-plan.md
@@ -2,7 +2,7 @@
 
 ## 1. Text Access and Verification
 - [x] Confirm the SBLGNT text for all books is available in the repository and document how to load it (verses, clauses, metadata). See `docs/sblgnt-data-access.md` for coverage notes and loading examples.
-- [ ] Provide a lightweight script/notebook to inspect raw text for sanity checks before building the viewer.
+- [x] Provide a lightweight script/notebook to inspect raw text for sanity checks before building the viewer. (`scripts/inspect_sblgnt.py` renders verses from both the plain-text and XML corpora, with filters for substring search and starting references.)
 - [ ] Identify any gaps that require LLM-assisted extraction or cleaning and log them for follow-up tasks.
 
 ## 2. Core HTML Viewer

--- a/scripts/inspect_sblgnt.py
+++ b/scripts/inspect_sblgnt.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Utility helpers for quick inspection of the SBLGNT corpus.
+
+This script is intentionally lightweight so that editors can spot-check
+verse content before investing time in UI work. It supports two modes:
+
+* listing the available books in the repository
+* printing selected verses from either the plain-text or XML corpora
+
+Examples
+--------
+List the book identifiers shipped with the repository::
+
+    python scripts/inspect_sblgnt.py --list-books
+
+Preview the first few verses of Mark from the XML corpus::
+
+    python scripts/inspect_sblgnt.py --book Mark --limit 5
+
+Show the same verses from the plain text file for comparison::
+
+    python scripts/inspect_sblgnt.py --book Mark --source text --limit 5
+
+Search for a phrase anywhere in the book and print the matching verses::
+
+    python scripts/inspect_sblgnt.py --book Mark --contains "Ἰησοῦ" --limit 10
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional, Sequence
+from xml.etree import ElementTree as ET
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEXT_DIR = REPO_ROOT / "external-data" / "SBLGNT" / "data" / "sblgnt" / "text"
+XML_DIR = REPO_ROOT / "external-data" / "SBLGNT" / "data" / "sblgnt" / "xml"
+
+
+@dataclass
+class Verse:
+    """Structured representation of a verse for display."""
+
+    reference: str
+    text: str
+    paragraph_index: Optional[int] = None
+
+
+def list_books(directory: Path, suffix: str) -> List[str]:
+    """Return sorted book identifiers found in ``directory``."""
+
+    return sorted(path.stem for path in directory.glob(f"*{suffix}"))
+
+
+def ensure_book(book: str, source: str) -> None:
+    """Validate that the selected book exists for the requested source."""
+
+    directory = TEXT_DIR if source == "text" else XML_DIR
+    suffix = ".txt" if source == "text" else ".xml"
+    if not (directory / f"{book}{suffix}").exists():
+        options = list_books(directory, suffix)
+        message = (
+            f"Unknown book '{book}' for source '{source}'.\n"
+            f"Available options: {', '.join(options)}"
+        )
+        raise SystemExit(message)
+
+
+def iter_plain_verses(book: str) -> Iterator[Verse]:
+    """Yield verses from the plain-text corpus.
+
+    The verse files align verses on the left margin and indent continuation
+    lines. We capture the book/chapter identifier as the first two tokens and
+    treat any indented lines as continuations of the current verse.
+    """
+
+    path = TEXT_DIR / f"{book}.txt"
+    with path.open(encoding="utf-8") as handle:
+        lines = handle.readlines()
+
+    if not lines:
+        return
+
+    # The first line is always the title in uppercase (e.g. ΚΑΤΑ ΜΑΡΚΟΝ).
+    title = lines[0].strip()
+    if title:
+        yield Verse(reference="TITLE", text=title, paragraph_index=None)
+
+    current_ref: Optional[str] = None
+    buffer: List[str] = []
+
+    for raw_line in lines[1:]:
+        if not raw_line.strip():
+            continue
+
+        if raw_line[0].isspace():
+            # Continuation of the current verse; just append trimmed text.
+            buffer.append(raw_line.strip())
+            continue
+
+        # Encountered a new verse header. Flush the previous verse first.
+        if current_ref is not None:
+            verse_text = " ".join(buffer).strip()
+            yield Verse(reference=current_ref, text=verse_text)
+            buffer = []
+
+        parts = raw_line.strip().split()
+        if len(parts) < 3:
+            # Not a verse line; skip but warn so the user can investigate.
+            print(
+                f"Skipping unexpected line in {book}.txt: {raw_line.rstrip()}",
+                file=sys.stderr,
+            )
+            current_ref = None
+            buffer = []
+            continue
+
+        current_ref = f"{parts[0]} {parts[1]}"
+        buffer.append(" ".join(parts[2:]))
+
+    if current_ref is not None:
+        verse_text = " ".join(buffer).strip()
+        yield Verse(reference=current_ref, text=verse_text)
+
+
+def iter_xml_verses(book: str) -> Iterator[Verse]:
+    """Yield verses from the XML corpus with prefixes and suffixes merged."""
+
+    path = XML_DIR / f"{book}.xml"
+    root = ET.parse(path).getroot()
+
+    verses: List[Verse] = []
+    current_ref: Optional[str] = None
+    parts: List[str] = []
+    prefix_buffer = ""
+    current_paragraph = -1
+    paragraph_index = -1
+
+    for node in root.iter():
+        tag = node.tag
+        if tag == "p":
+            paragraph_index += 1
+        elif tag == "verse-number":
+            if current_ref is not None:
+                verses.append(
+                    Verse(
+                        reference=current_ref,
+                        text="".join(parts).strip(),
+                        paragraph_index=current_paragraph,
+                    )
+                )
+                parts = []
+            current_ref = node.attrib.get("id", node.text or "")
+            current_paragraph = paragraph_index
+            prefix_buffer = ""
+        elif tag == "prefix":
+            if node.text:
+                prefix_buffer += node.text
+        elif tag == "w":
+            if not node.text:
+                continue
+            if prefix_buffer:
+                token = f"{prefix_buffer}{node.text}"
+            else:
+                needs_space = bool(parts) and not parts[-1].endswith(" ")
+                token = (" " if needs_space else "") + node.text
+            parts.append(token)
+            prefix_buffer = ""
+        elif tag == "suffix":
+            if node.text:
+                parts.append(node.text)
+
+    if current_ref is not None:
+        verses.append(
+            Verse(
+                reference=current_ref,
+                text="".join(parts).strip(),
+                paragraph_index=current_paragraph,
+            )
+        )
+
+    return iter(verses)
+
+
+def filter_verses(
+    verses: Iterable[Verse],
+    *,
+    start: Optional[str] = None,
+    contains: Optional[str] = None,
+) -> List[Verse]:
+    """Apply optional filters to a verse sequence and return a list."""
+
+    collected = list(verses)
+    if start:
+        start_lower = start.lower()
+        for index, verse in enumerate(collected):
+            if verse.reference.lower().startswith(start_lower):
+                collected = collected[index:]
+                break
+        else:
+            raise SystemExit(f"Start reference '{start}' not found in selection")
+
+    if contains:
+        collected = [verse for verse in collected if contains in verse.text]
+
+    return collected
+
+
+def format_verse(verse: Verse, *, width: int = 88, show_paragraphs: bool = False) -> str:
+    """Format a verse for console output."""
+
+    reference = verse.reference
+    if show_paragraphs and verse.paragraph_index is not None:
+        reference = f"{reference} [¶{verse.paragraph_index}]"
+
+    indent = " " * (len(reference) + 2)
+    wrapped = textwrap.fill(
+        verse.text,
+        width=width,
+        initial_indent=f"{reference}: ",
+        subsequent_indent=indent,
+        replace_whitespace=False,
+    )
+    return wrapped
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--book", default="Mark", help="Book identifier to inspect")
+    parser.add_argument(
+        "--source",
+        choices=("xml", "text"),
+        default="xml",
+        help="Corpus to use for verse extraction",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum number of verses to display (0 shows everything)",
+    )
+    parser.add_argument(
+        "--start",
+        help="Start output at the first verse whose reference starts with this value",
+    )
+    parser.add_argument(
+        "--contains",
+        help="Filter verses to those containing this exact substring",
+    )
+    parser.add_argument(
+        "--list-books",
+        action="store_true",
+        help="Only list the available books for the selected source",
+    )
+    parser.add_argument(
+        "--show-paragraphs",
+        action="store_true",
+        help="Include paragraph indices when rendering XML verses",
+    )
+    parser.add_argument(
+        "--width",
+        type=int,
+        default=88,
+        help="Wrap verse output to this column width",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+
+    directory = TEXT_DIR if args.source == "text" else XML_DIR
+    suffix = ".txt" if args.source == "text" else ".xml"
+
+    if args.list_books:
+        books = list_books(directory, suffix)
+        for book in books:
+            print(book)
+        return 0
+
+    ensure_book(args.book, args.source)
+
+    if args.source == "text":
+        verses = list(iter_plain_verses(args.book))
+    else:
+        verses = list(iter_xml_verses(args.book))
+
+    # TITLE entries make sense for the plain text output but we hide them if the
+    # caller applies substring filtering since the title is rarely relevant.
+    if args.contains and verses and verses[0].reference == "TITLE":
+        verses = verses[1:]
+
+    verses = filter_verses(verses, start=args.start, contains=args.contains)
+
+    to_render: Iterable[Verse]
+    if args.limit and args.limit > 0:
+        to_render = verses[: args.limit]
+    else:
+        to_render = verses
+
+    if not to_render:
+        print("No verses matched the requested filters.")
+        return 0
+
+    for verse in to_render:
+        if verse.reference == "TITLE":
+            print(verse.text)
+        else:
+            print(format_verse(verse, width=args.width, show_paragraphs=args.show_paragraphs))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- embed real example output for the SBLGNT inspection helper commands in the data access notes
- note the aggregated corpus file that appears in the book list output
- update the agent guidelines to require documenting non-CI commands with captured output

## Testing
- python scripts/inspect_sblgnt.py --list-books
- python scripts/inspect_sblgnt.py --book Mark --limit 5
- python scripts/inspect_sblgnt.py --book Mark --source text --limit 5
- python scripts/inspect_sblgnt.py --book Luke --contains "Ἰησοῦ" --limit 10

------
https://chatgpt.com/codex/tasks/task_e_68c971899b748324b90087c4344513da