### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,3 +27,44 @@ jobs:
         run: |
           coverage run -m pytest
           coverage report
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Build viewer dataset
+        run: |
+          python scripts/build_viewer_data.py \
+            external-data/SBLGNT/data/sblgnt/text/Mark.txt \
+            viewer/data/mark.json \
+            --display-name "Gospel of Mark" \
+            --book-id mark
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload viewer artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: viewer
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/github-pages-deployment.md
+++ b/docs/github-pages-deployment.md
@@ -1,0 +1,28 @@
+# GitHub Pages Deployment
+
+The `Tests` workflow now includes an automated deployment job that publishes the static viewer.
+Whenever a pull request is merged into the `main` branch (triggering a `push` to `main`), the
+pipeline will:
+
+1. Rebuild the viewer dataset from the SBLGNT source text so the JSON payload in
+   `viewer/data/mark.json` stays in sync with the repository state.
+2. Package the entire `viewer/` directory as the GitHub Pages artifact.
+3. Deploy the artifact via the official `actions/deploy-pages` action, making the site available
+   through the `github-pages` environment.
+
+The deployment job only runs after the tests succeed on `main`; pull requests and other branches do
+not trigger a deploy.
+
+## Enabling GitHub Pages in the Repository Settings
+
+To allow the workflow to publish the site, configure GitHub Pages to use GitHub Actions:
+
+1. Navigate to the repository on GitHub and open **Settings**.
+2. In the sidebar, select **Pages**.
+3. Under **Build and deployment**, set **Source** to **GitHub Actions**.
+4. Save the settings. GitHub will remember that deployments come from the workflow’s `github-pages`
+   environment.
+5. After the first successful run on `main`, visit the deployment listed under the repository’s
+   **Environments** page or the link in the workflow summary to reach the published viewer.
+
+With these settings in place, every merge to `main` automatically rebuilds and publishes the site.


### PR DESCRIPTION
## Summary
- extend the CI workflow with a GitHub Pages deployment job that runs after tests succeed on `main`
- rebuild the viewer dataset during deployment and publish the `viewer/` directory via the Pages actions
- document the repository settings required to enable GitHub Pages deployments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca3d85b70c8324b0eb216ccbe9919a