### PR TITLE
Add viewer tests with enforced coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,3 +27,12 @@ jobs:
         run: |
           coverage run -m pytest
           coverage report
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run viewer tests
+        working-directory: viewer
+        run: npm test

--- a/viewer/js/__tests__/main.test.js
+++ b/viewer/js/__tests__/main.test.js
@@ -1,0 +1,441 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { mock } = require("node:test");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const { createViewer, bootstrap } = require("../main.js");
+
+class MockElement {
+  constructor(tagName) {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.dataset = {};
+    this.style = {};
+    this.className = "";
+    this._textContent = "";
+    this._innerHTML = "";
+  }
+
+  append(...nodes) {
+    for (const node of nodes) {
+      this.appendChild(node);
+    }
+  }
+
+  appendChild(node) {
+    if (!node) {
+      return node;
+    }
+
+    if (node.isFragment) {
+      for (const child of node.children) {
+        this.children.push(child);
+      }
+    } else {
+      this.children.push(node);
+    }
+    return node;
+  }
+
+  get textContent() {
+    return this._textContent;
+  }
+
+  set textContent(value) {
+    this._textContent = value;
+  }
+
+  get innerHTML() {
+    return this._innerHTML;
+  }
+
+  set innerHTML(value) {
+    this._innerHTML = value;
+    if (value === "") {
+      this.children = [];
+    }
+  }
+
+  querySelectorAll(selector) {
+    const [tagPart, classPart] = selector.split(".");
+    const expectedTag = tagPart ? tagPart.toUpperCase() : null;
+    const expectedClass = classPart || null;
+    const matches = [];
+
+    function visit(node) {
+      for (const child of node.children) {
+        const tagMatches = !expectedTag || child.tagName === expectedTag;
+        const classMatches = !expectedClass || child.className === expectedClass;
+        if (tagMatches && classMatches) {
+          matches.push(child);
+        }
+        visit(child);
+      }
+    }
+
+    visit(this);
+    return matches;
+  }
+}
+
+class MockDocumentFragment {
+  constructor() {
+    this.children = [];
+    this.isFragment = true;
+  }
+
+  appendChild(node) {
+    this.children.push(node);
+    return node;
+  }
+}
+
+class MockDocument {
+  constructor() {
+    this.elements = new Map();
+    this.listeners = new Map();
+    this.readyState = "complete";
+    this.title = "";
+  }
+
+  register(id, element) {
+    this.elements.set(id, element);
+    return element;
+  }
+
+  getElementById(id) {
+    return this.elements.get(id) || null;
+  }
+
+  createElement(tagName) {
+    return new MockElement(tagName);
+  }
+
+  createDocumentFragment() {
+    return new MockDocumentFragment();
+  }
+
+  addEventListener(type, handler) {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, new Set());
+    }
+    this.listeners.get(type).add(handler);
+  }
+
+  removeEventListener(type, handler) {
+    if (!this.listeners.has(type)) {
+      return;
+    }
+    this.listeners.get(type).delete(handler);
+  }
+
+  dispatchEvent(event) {
+    const handlers = this.listeners.get(event.type);
+    if (!handlers) {
+      return;
+    }
+    for (const handler of handlers) {
+      handler.call(this, event);
+    }
+  }
+}
+
+function buildDocument() {
+  const doc = new MockDocument();
+  const statusEl = doc.register("viewer-status", new MockElement("div"));
+  const containerEl = doc.register("text-container", new MockElement("section"));
+  const displayEl = doc.register("book-display", new MockElement("h1"));
+  const headerEl = doc.register("book-header", new MockElement("p"));
+  return { doc, statusEl, containerEl, displayEl, headerEl };
+}
+
+async function flushAsyncOperations() {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+test("setStatus updates the message panel", () => {
+  const { doc, statusEl } = buildDocument();
+  const viewer = createViewer({ document: doc });
+
+  viewer.setStatus("Loaded");
+  assert.equal(statusEl.textContent, "Loaded");
+  assert.equal(statusEl.style.display, "block");
+  assert.equal(statusEl.style.borderLeftColor, "");
+
+  viewer.setStatus("Problem", true);
+  assert.equal(statusEl.style.borderLeftColor, "#a23b3b");
+
+  viewer.setStatus("");
+  assert.equal(statusEl.textContent, "");
+  assert.equal(statusEl.style.display, "none");
+  assert.equal(statusEl.style.borderLeftColor, "");
+});
+
+test("setStatus safely no-ops when the status element is absent", () => {
+  const doc = new MockDocument();
+  doc.register("text-container", new MockElement("section"));
+  doc.register("book-display", new MockElement("h1"));
+  doc.register("book-header", new MockElement("p"));
+
+  const viewer = createViewer({ document: doc });
+
+  assert.doesNotThrow(() => viewer.setStatus("Ready"));
+});
+
+test("renderVerses populates the container", () => {
+  const { doc, containerEl } = buildDocument();
+  const viewer = createViewer({ document: doc });
+
+  viewer.renderVerses([
+    { reference: "Mk 1:1", text: "Ἀρχὴ τοῦ εὐαγγελίου" },
+    { reference: "Mk 1:2", text: "καθὼς γέγραπται" },
+  ]);
+
+  assert.equal(containerEl.children.length, 2);
+  const [firstVerse] = containerEl.children;
+  assert.equal(firstVerse.className, "verse");
+  assert.equal(firstVerse.children[0].className, "verse-ref");
+  assert.equal(firstVerse.children[0].textContent, "Mk 1:1");
+  assert.equal(firstVerse.children[1].className, "verse-text");
+  assert.equal(firstVerse.children[1].textContent, "Ἀρχὴ τοῦ εὐαγγελίου");
+});
+
+test("renderVerses exits early when the container is missing", () => {
+  const doc = new MockDocument();
+  const statusEl = doc.register("viewer-status", new MockElement("div"));
+  const viewer = createViewer({ document: doc });
+
+  viewer.renderVerses([{ reference: "Mk 1:1", text: "Ἀρχὴ" }]);
+
+  assert.equal(statusEl.textContent, "");
+  assert.equal(statusEl.style.display, undefined);
+});
+
+test("renderVerses shows an error when the data is empty", () => {
+  const { doc, statusEl, containerEl } = buildDocument();
+  const viewer = createViewer({ document: doc });
+
+  containerEl.children.push(new MockElement("article"));
+  viewer.renderVerses([]);
+
+  assert.equal(statusEl.textContent, "No verse data available.");
+  assert.equal(statusEl.style.borderLeftColor, "#a23b3b");
+  assert.equal(containerEl.children.length, 0);
+});
+
+test("loadBook fetches the data and updates the document", async () => {
+  const { doc, statusEl, displayEl, headerEl, containerEl } = buildDocument();
+  const fetchMock = mock.fn(async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return {
+        display_name: "Gospel of Mark",
+        header: "A fast-paced narrative",
+        verses: [
+          { reference: "Mk 1:1", text: "Ἀρχὴ τοῦ εὐαγγελίου" },
+        ],
+      };
+    },
+  }));
+
+  const viewer = createViewer({ document: doc, fetch: fetchMock });
+
+  const payload = await viewer.loadBook();
+
+  assert.equal(fetchMock.mock.calls.length, 1);
+  assert.deepEqual(fetchMock.mock.calls[0].arguments, ["data/mark.json", { cache: "no-cache" }]);
+  assert.equal(payload.display_name, "Gospel of Mark");
+  assert.equal(displayEl.textContent, "Gospel of Mark");
+  assert.equal(headerEl.textContent, "A fast-paced narrative");
+  assert.equal(doc.title, "Gospel of Mark · SBLGNT Viewer");
+  assert.equal(statusEl.textContent, "");
+  assert.equal(statusEl.style.display, "none");
+  assert.equal(containerEl.children.length, 1);
+});
+
+test("loadBook reports failures and leaves an error message", async () => {
+  const { doc, statusEl } = buildDocument();
+  const consoleMock = { error: mock.fn() };
+  const fetchMock = mock.fn(async () => ({ ok: false, status: 503, async json() {} }));
+
+  const viewer = createViewer({ document: doc, fetch: fetchMock, console: consoleMock });
+
+  const result = await viewer.loadBook();
+
+  assert.equal(result, null);
+  assert.equal(statusEl.textContent, "Unable to load the Gospel of Mark at this time.");
+  assert.equal(statusEl.style.display, "block");
+  assert.equal(statusEl.style.borderLeftColor, "#a23b3b");
+  assert.equal(consoleMock.error.mock.calls.length, 1);
+});
+
+test("loadBook tolerates console objects without an error method", async () => {
+  const { doc, statusEl } = buildDocument();
+  const fetchMock = mock.fn(async () => ({ ok: false, status: 500, async json() {} }));
+
+  const viewer = createViewer({ document: doc, fetch: fetchMock, console: {} });
+
+  const result = await viewer.loadBook();
+
+  assert.equal(result, null);
+  assert.equal(statusEl.style.display, "block");
+  assert.equal(statusEl.textContent, "Unable to load the Gospel of Mark at this time.");
+});
+
+test("loadBook returns null when display elements are not available", async () => {
+  const doc = new MockDocument();
+  doc.register("viewer-status", new MockElement("div"));
+  doc.register("text-container", new MockElement("section"));
+  const fetchMock = mock.fn(async () => ({ ok: true, status: 200, async json() { return {}; } }));
+
+  const viewer = createViewer({ document: doc, fetch: fetchMock });
+
+  const result = await viewer.loadBook();
+
+  assert.equal(result, null);
+  assert.equal(fetchMock.mock.calls.length, 0);
+});
+
+test("loadBook handles a missing fetch implementation", async () => {
+  const { doc, statusEl } = buildDocument();
+  const consoleMock = { error: mock.fn() };
+
+  const viewer = createViewer({ document: doc, fetch: null, console: consoleMock });
+
+  const result = await viewer.loadBook();
+
+  assert.equal(result, null);
+  assert.equal(statusEl.textContent, "Unable to load the Gospel of Mark at this time.");
+  assert.equal(consoleMock.error.mock.calls.length, 1);
+});
+
+test("init returns false when required elements are missing", () => {
+  const doc = new MockDocument();
+  const viewer = createViewer({ document: doc });
+
+  assert.equal(viewer.init(), false);
+});
+
+test("init waits for DOMContentLoaded when the document is loading", async () => {
+  const { doc } = buildDocument();
+  doc.readyState = "loading";
+  const fetchMock = mock.fn(async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return {
+        display_name: "Mark",
+        header: "",
+        verses: [{ reference: "Mk 1:1", text: "Ἀρχὴ" }],
+      };
+    },
+  }));
+
+  const viewer = createViewer({ document: doc, fetch: fetchMock });
+
+  assert.equal(viewer.init(), true);
+  assert.equal(fetchMock.mock.calls.length, 0);
+
+  doc.dispatchEvent({ type: "DOMContentLoaded" });
+  await flushAsyncOperations();
+
+  assert.equal(fetchMock.mock.calls.length, 1);
+});
+
+test("init triggers a load immediately when the document is ready", async () => {
+  const { doc } = buildDocument();
+  const fetchMock = mock.fn(async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return {
+        display_name: "Mark",
+        header: "",
+        verses: [],
+      };
+    },
+  }));
+
+  const viewer = createViewer({ document: doc, fetch: fetchMock });
+
+  assert.equal(viewer.init(), true);
+  await flushAsyncOperations();
+  assert.equal(fetchMock.mock.calls.length, 1);
+});
+
+test("browser build initializes itself in a window context", async () => {
+  const filePath = path.join(__dirname, "../main.js");
+  const source = fs.readFileSync(filePath, "utf8");
+  const { doc } = buildDocument();
+  doc.readyState = "loading";
+
+  const fetchMock = mock.fn(async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return {
+        display_name: "Mark",
+        header: "",
+        verses: [{ reference: "Mk 1:1", text: "Ἀρχὴ" }],
+      };
+    },
+  }));
+
+  const consoleMock = { error: mock.fn() };
+
+  const windowObject = {
+    document: doc,
+  };
+
+  const context = {
+    window: windowObject,
+    document: doc,
+    fetch: fetchMock,
+    console: consoleMock,
+  };
+  context.globalThis = context;
+  windowObject.fetch = fetchMock;
+  windowObject.console = consoleMock;
+  windowObject.globalThis = context;
+
+  vm.createContext(context);
+  vm.runInContext(source, context, { filename: "main.js" });
+
+  assert.ok(windowObject.SBLGNTViewer);
+  assert.equal(typeof windowObject.SBLGNTViewer.init, "function");
+  doc.dispatchEvent({ type: "DOMContentLoaded" });
+  await flushAsyncOperations();
+
+  assert.equal(fetchMock.mock.calls.length, 1);
+});
+
+test("bootstrap attaches the viewer to the provided global object", async () => {
+  const { doc } = buildDocument();
+  doc.readyState = "loading";
+  const fetchMock = mock.fn(async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return {
+        display_name: "Mark",
+        header: "",
+        verses: [{ reference: "Mk 1:1", text: "Ἀρχὴ" }],
+      };
+    },
+  }));
+
+  const globalObject = { document: doc, fetch: fetchMock, console: { error() {} } };
+
+  const viewerInstance = bootstrap(globalObject);
+
+  assert.ok(viewerInstance);
+  assert.equal(globalObject.SBLGNTViewer, viewerInstance);
+
+  doc.dispatchEvent({ type: "DOMContentLoaded" });
+  await flushAsyncOperations();
+
+  assert.equal(fetchMock.mock.calls.length, 1);
+});

--- a/viewer/js/main.js
+++ b/viewer/js/main.js
@@ -1,76 +1,169 @@
-(function () {
-  const statusEl = document.getElementById("viewer-status");
-  const containerEl = document.getElementById("text-container");
-  const displayEl = document.getElementById("book-display");
-  const headerEl = document.getElementById("book-header");
+(function (global, factory) {
+  const viewerModule = factory();
+  if (typeof module === "object" && typeof module.exports === "object") {
+    module.exports = viewerModule;
+  }
+  viewerModule.bootstrap(global);
+})(typeof window !== "undefined" ? window : undefined, function () {
+  const fallbackGlobal = typeof globalThis !== "undefined" ? globalThis : {};
 
-  function setStatus(message, isError = false) {
-    if (!statusEl) {
-      return;
+  function resolveConsole(consoleObj) {
+    if (consoleObj && typeof consoleObj.error === "function") {
+      return consoleObj;
     }
-    if (message) {
-      statusEl.textContent = message;
-      statusEl.style.display = "block";
-      statusEl.style.borderLeftColor = isError ? "#a23b3b" : "";
-    } else {
-      statusEl.textContent = "";
-      statusEl.style.display = "none";
-    }
+    return {
+      error() {
+        /* noop */
+      },
+    };
   }
 
-  function renderVerses(verses) {
-    if (!Array.isArray(verses) || verses.length === 0) {
-      setStatus("No verse data available.", true);
-      return;
-    }
+  function createViewer({
+    document: doc = fallbackGlobal.document || null,
+    fetch: fetchFn = fallbackGlobal.fetch || null,
+    console: consoleObj = fallbackGlobal.console || null,
+  } = {}) {
+    const statusEl = doc ? doc.getElementById("viewer-status") : null;
+    const containerEl = doc ? doc.getElementById("text-container") : null;
+    const displayEl = doc ? doc.getElementById("book-display") : null;
+    const headerEl = doc ? doc.getElementById("book-header") : null;
+    const safeConsole = resolveConsole(consoleObj);
 
-    containerEl.innerHTML = "";
-
-    const fragment = document.createDocumentFragment();
-    for (const verse of verses) {
-      const verseEl = document.createElement("article");
-      verseEl.className = "verse";
-      verseEl.dataset.reference = verse.reference;
-
-      const referenceEl = document.createElement("span");
-      referenceEl.className = "verse-ref";
-      referenceEl.textContent = verse.reference;
-
-      const textEl = document.createElement("span");
-      textEl.className = "verse-text";
-      textEl.textContent = verse.text;
-
-      verseEl.append(referenceEl, textEl);
-      fragment.appendChild(verseEl);
-    }
-
-    containerEl.appendChild(fragment);
-  }
-
-  async function loadBook() {
-    try {
-      setStatus("Loading the SBLGNT text…");
-      const response = await fetch("data/mark.json", { cache: "no-cache" });
-      if (!response.ok) {
-        throw new Error(`Request failed with status ${response.status}`);
+    function setStatus(message, isError = false) {
+      if (!statusEl) {
+        return;
       }
 
-      const payload = await response.json();
-      const { display_name: displayName, header, verses } = payload;
-
-      displayEl.textContent = displayName || "Gospel of Mark";
-      headerEl.textContent = header || "";
-      document.title = `${displayEl.textContent} · SBLGNT Viewer`;
-
-      renderVerses(verses);
-      setStatus("");
-    } catch (error) {
-      console.error(error);
-      setStatus("Unable to load the Gospel of Mark at this time.", true);
+      if (message) {
+        statusEl.textContent = message;
+        statusEl.style.display = "block";
+        statusEl.style.borderLeftColor = isError ? "#a23b3b" : "";
+      } else {
+        statusEl.textContent = "";
+        statusEl.style.display = "none";
+        statusEl.style.borderLeftColor = "";
+      }
     }
+
+    function renderVerses(verses) {
+      if (!Array.isArray(verses) || verses.length === 0) {
+        setStatus("No verse data available.", true);
+        if (containerEl) {
+          containerEl.innerHTML = "";
+        }
+        return;
+      }
+
+      if (!containerEl || !doc) {
+        return;
+      }
+
+      containerEl.innerHTML = "";
+
+      const fragment = doc.createDocumentFragment();
+      for (const verse of verses) {
+        const verseEl = doc.createElement("article");
+        verseEl.className = "verse";
+        verseEl.dataset.reference = verse.reference;
+
+        const referenceEl = doc.createElement("span");
+        referenceEl.className = "verse-ref";
+        referenceEl.textContent = verse.reference;
+
+        const textEl = doc.createElement("span");
+        textEl.className = "verse-text";
+        textEl.textContent = verse.text;
+
+        verseEl.append(referenceEl, textEl);
+        fragment.appendChild(verseEl);
+      }
+
+      containerEl.appendChild(fragment);
+    }
+
+    async function loadBook() {
+      if (!displayEl || !headerEl) {
+        return null;
+      }
+
+      setStatus("Loading the SBLGNT text…");
+
+      try {
+        if (!fetchFn) {
+          throw new Error("Fetch API is not available");
+        }
+
+        const response = await fetchFn("data/mark.json", { cache: "no-cache" });
+        if (!response || !response.ok) {
+          const status = response ? response.status : "unknown";
+          throw new Error(`Request failed with status ${status}`);
+        }
+
+        const payload = await response.json();
+        const displayName = payload.display_name || "Gospel of Mark";
+        const header = payload.header || "";
+
+        displayEl.textContent = displayName;
+        headerEl.textContent = header;
+        if (doc) {
+          doc.title = `${displayName} · SBLGNT Viewer`;
+        }
+
+        renderVerses(payload.verses);
+        setStatus("");
+        return payload;
+      } catch (error) {
+        safeConsole.error(error);
+        setStatus("Unable to load the Gospel of Mark at this time.", true);
+        return null;
+      }
+    }
+
+    function init() {
+      if (!doc || !containerEl || !displayEl || !headerEl) {
+        return false;
+      }
+
+      if (doc.readyState === "loading") {
+        const onReady = () => {
+          doc.removeEventListener("DOMContentLoaded", onReady);
+          void loadBook();
+        };
+        doc.addEventListener("DOMContentLoaded", onReady);
+      } else {
+        void loadBook();
+      }
+      return true;
+    }
+
+    return {
+      init,
+      loadBook,
+      renderVerses,
+      setStatus,
+      elements: {
+        statusEl,
+        containerEl,
+        displayEl,
+        headerEl,
+      },
+    };
   }
 
-  if (containerEl && displayEl && headerEl) {
-    window.addEventListener("DOMContentLoaded", loadBook);
+  function bootstrap(globalTarget) {
+    const viewerInstance = createViewer({
+      document: globalTarget && globalTarget.document,
+      fetch: globalTarget && globalTarget.fetch,
+      console: globalTarget && globalTarget.console,
+    });
+
+    if (globalTarget) {
+      globalTarget.SBLGNTViewer = viewerInstance;
+    }
+
+    viewerInstance.init();
+    return viewerInstance;
   }
-})();
+
+  return { createViewer, bootstrap };
+});

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "sblgnt-viewer",
+  "version": "1.0.0",
+  "private": true,
+  "description": "SBLGNT web viewer",
+  "scripts": {
+    "test": "node ./scripts/run-tests.js"
+  },
+  "keywords": [
+    "sblgnt",
+    "viewer"
+  ],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs"
+}

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -12,5 +12,9 @@
   ],
   "author": "",
   "license": "MIT",
-  "type": "commonjs"
+  "type": "commonjs",
+  "config": {
+    "viewerCoverageThreshold": 80,
+    "viewerCoverageTarget": "js/main.js"
+  }
 }

--- a/viewer/scripts/run-tests.js
+++ b/viewer/scripts/run-tests.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+const { spawnSync } = require("node:child_process");
+const path = require("node:path");
+
+const projectRoot = path.resolve(__dirname, "..");
+
+const result = spawnSync(process.execPath, ["--test", "--experimental-test-coverage"], {
+  cwd: projectRoot,
+  env: process.env,
+  encoding: "utf8",
+});
+
+process.stdout.write(result.stdout);
+process.stderr.write(result.stderr);
+
+if (result.status !== 0) {
+  process.exit(result.status);
+}
+
+const coveragePattern = /js\/main\.js\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)/;
+const match = coveragePattern.exec(result.stdout);
+
+if (!match) {
+  console.error("Unable to find coverage results for js/main.js");
+  process.exit(1);
+}
+
+const thresholds = {
+  lines: parseFloat(match[1]),
+  branches: parseFloat(match[2]),
+  functions: parseFloat(match[3]),
+};
+
+const minimum = 80;
+const failures = Object.entries(thresholds)
+  .filter(([, value]) => Number.isFinite(value) && value < minimum)
+  .map(([metric, value]) => `${metric} ${value.toFixed(2)}%`);
+
+if (failures.length > 0) {
+  console.error(
+    `Coverage for js/main.js is below the required ${minimum}% for: ${failures.join(", ")}`,
+  );
+  process.exit(1);
+}

--- a/viewer/scripts/run-tests.js
+++ b/viewer/scripts/run-tests.js
@@ -4,11 +4,74 @@ const path = require("node:path");
 
 const projectRoot = path.resolve(__dirname, "..");
 
-const result = spawnSync(process.execPath, ["--test", "--experimental-test-coverage"], {
-  cwd: projectRoot,
-  env: process.env,
-  encoding: "utf8",
-});
+function parsePositiveNumber(value) {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value >= 0 ? value : null;
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    return null;
+  }
+  const parsed = Number.parseFloat(trimmed);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function firstDefined(...values) {
+  for (const value of values) {
+    if (value !== undefined && value !== null) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function getCoverageThreshold() {
+  const candidate = firstDefined(
+    process.env.VIEWER_COVERAGE_THRESHOLD,
+    process.env.COVERAGE_THRESHOLD,
+    process.env.npm_config_viewer_coverage_threshold,
+    process.env.npm_package_config_viewerCoverageThreshold,
+  );
+  const parsed = parsePositiveNumber(candidate);
+  return parsed === null ? 80 : parsed;
+}
+
+function getCoverageTarget() {
+  const candidate = firstDefined(
+    process.env.VIEWER_COVERAGE_TARGET,
+    process.env.npm_config_viewer_coverage_target,
+    process.env.npm_package_config_viewerCoverageTarget,
+  );
+  if (typeof candidate === "string" && candidate.trim() !== "") {
+    return candidate.trim();
+  }
+  return "js/main.js";
+}
+
+function escapeForRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const minimum = getCoverageThreshold();
+const coverageTarget = getCoverageTarget();
+
+const extraArgs =
+  typeof process.env.VIEWER_TEST_ARGS === "string" && process.env.VIEWER_TEST_ARGS.trim() !== ""
+    ? process.env.VIEWER_TEST_ARGS.trim().split(/\s+/)
+    : [];
+
+const result = spawnSync(
+  process.execPath,
+  ["--test", "--experimental-test-coverage", ...extraArgs],
+  {
+    cwd: projectRoot,
+    env: process.env,
+    encoding: "utf8",
+  },
+);
 
 process.stdout.write(result.stdout);
 process.stderr.write(result.stderr);
@@ -17,11 +80,13 @@ if (result.status !== 0) {
   process.exit(result.status);
 }
 
-const coveragePattern = /js\/main\.js\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)/;
+const coveragePattern = new RegExp(
+  `${escapeForRegex(coverageTarget)}\\s*\\|\\s*([\\d.]+)\\s*\\|\\s*([\\d.]+)\\s*\\|\\s*([\\d.]+)`,
+);
 const match = coveragePattern.exec(result.stdout);
 
 if (!match) {
-  console.error("Unable to find coverage results for js/main.js");
+  console.error(`Unable to find coverage results for ${coverageTarget}`);
   process.exit(1);
 }
 
@@ -31,14 +96,13 @@ const thresholds = {
   functions: parseFloat(match[3]),
 };
 
-const minimum = 80;
 const failures = Object.entries(thresholds)
   .filter(([, value]) => Number.isFinite(value) && value < minimum)
   .map(([metric, value]) => `${metric} ${value.toFixed(2)}%`);
 
 if (failures.length > 0) {
   console.error(
-    `Coverage for js/main.js is below the required ${minimum}% for: ${failures.join(", ")}`,
+    `Coverage for ${coverageTarget} is below the required ${minimum}% for: ${failures.join(", ")}`,
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- Refactor the viewer bootstrap to expose a `createViewer` factory and `bootstrap` helper that support dependency injection, better error handling, and graceful initialization in both browser and Node contexts.【F:viewer/js/main.js†L1-L169】
- Add a comprehensive Node-based test suite with lightweight DOM mocks that exercises rendering, loading, initialization, and browser bootstrap behaviors while covering error paths.【F:viewer/js/__tests__/main.test.js†L1-L218】
- Introduce a viewer-specific `package.json` and coverage-checking test script, and wire the CI workflow to run the viewer tests with an 80% coverage gate.【F:viewer/package.json†L1-L16】【F:viewer/scripts/run-tests.js†L1-L34】【F:.github/workflows/tests.yml†L31-L38】

## Testing
- `npm test`【851e96†L1-L46】
- `pytest`【1b42ea†L1-L10】

------
https://chatgpt.com/codex/tasks/task_e_68ca3d6263348324b5b3cb9a9695e1cd