### PR TITLE
Fix GitHub Pages deployment by fetching submodules

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -43,6 +45,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
## Summary
- ensure both test and deploy jobs check out repository submodules so SBLGNT data is available during CI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca40e64300832494b772c9d27df31e