### PR TITLE
Add manifest-driven book selector to viewer

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -12,6 +12,17 @@
         <p class="app-overline">Greek Text Viewer</p>
         <h1 id="book-display" class="app-title">Loading…</h1>
         <p id="book-header" class="app-subtitle" aria-live="polite"></p>
+        <div class="book-picker" id="book-selector-container">
+          <label class="book-picker-label" for="book-selector">Choose a text</label>
+          <select
+            id="book-selector"
+            class="book-picker-select"
+            aria-label="Available SBLGNT texts"
+            disabled
+          >
+            <option>Loading available texts…</option>
+          </select>
+        </div>
       </div>
     </header>
     <main class="app-shell" aria-live="polite">

--- a/viewer/styles/main.css
+++ b/viewer/styles/main.css
@@ -55,6 +55,44 @@ body {
   letter-spacing: 0.08em;
 }
 
+.book-picker {
+  margin: 1.5rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 20rem;
+}
+
+.book-picker-label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.book-picker-select {
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: var(--card-bg);
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-family: inherit;
+  box-shadow: 0 6px 18px rgba(35, 31, 32, 0.08);
+}
+
+.book-picker-select:focus {
+  outline: 2px solid rgba(150, 112, 91, 0.35);
+  outline-offset: 2px;
+}
+
+.book-picker-select:disabled {
+  background: rgba(150, 112, 91, 0.1);
+  color: var(--text-muted);
+  cursor: not-allowed;
+}
+
 .app-footer {
   margin-top: 3rem;
   border-top: 1px solid var(--border);
@@ -113,6 +151,11 @@ body {
 @media (max-width: 720px) {
   .app-shell {
     padding: 1.25rem 1rem;
+  }
+
+  .book-picker {
+    margin-top: 1rem;
+    max-width: none;
   }
 
   .verse {


### PR DESCRIPTION
## Summary
- add an interactive book picker fed by the manifest and wire it into viewer initialization
- update styling and markup so the selector surfaces alongside the existing book header
- expand the Node test suite to cover manifest edge cases, selection flows, and bootstrap configuration paths

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca4c641c308324af73c81ea0563dfd