### PR TITLE
Add loader state handling for viewer book fetches

### DIFF
--- a/plans/gospel-of-mark-plan.md
+++ b/plans/gospel-of-mark-plan.md
@@ -9,7 +9,7 @@
 - [x] Draft a minimal HTML/CSS scaffold that renders beautifully formatted Greek text for a selected book (start with Mark).
 - [x] Generate a manifest of available viewer JSON payloads as part of the build step.
 - [x] Add a UI control that surfaces the manifest and lets readers choose a book.
-- [ ] Wire the loader to fetch the selected book, with loading/empty states for clarity.
+- [x] Wire the loader to fetch the selected book, with loading/empty states for clarity.
 - [ ] Index chapter and verse boundaries so navigation controls know their targets.
 - [ ] Implement direct chapter/verse jump inputs backed by the index.
 - [ ] Add next/previous navigation shortcuts and verify they sync with the main text view.

--- a/viewer/styles/main.css
+++ b/viewer/styles/main.css
@@ -114,6 +114,45 @@ body {
   display: grid;
   gap: 1rem;
   margin: 2rem 0 4rem;
+  min-height: 4rem;
+  position: relative;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.verse-list::before {
+  display: none;
+}
+
+.verse-list[data-state="loading"],
+.verse-list[data-state="empty"],
+.verse-list[data-state="error"] {
+  align-content: start;
+}
+
+.verse-list[data-state="loading"]::before,
+.verse-list[data-state="empty"]::before,
+.verse-list[data-state="error"]::before {
+  display: block;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  background: rgba(150, 112, 91, 0.08);
+  color: var(--text-muted);
+  text-align: center;
+  font-style: italic;
+}
+
+.verse-list[data-state="loading"]::before {
+  content: attr(data-loading-text);
+}
+
+.verse-list[data-state="empty"]::before {
+  content: attr(data-empty-text);
+}
+
+.verse-list[data-state="error"]::before {
+  content: attr(data-error-text);
+  border-left: 4px solid #a23b3b;
 }
 
 .verse {


### PR DESCRIPTION
## Summary
- add viewer container state management and message syncing to show loading, empty, and error feedback while fetching books
- extend the node-based viewer tests with attribute support and assertions covering the new container states
- style the verse list state overlays and mark the loader step complete in the viewer plan

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca547abddc8324b52501bd12d55016