### PR TITLE
Add direct reference jump controls to viewer

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -23,6 +23,53 @@
             <option>Loading available texts…</option>
           </select>
         </div>
+        <div class="reader-navigation" id="reference-navigation">
+          <form
+            id="reference-jump-form"
+            class="reader-navigation__form"
+            aria-label="Jump to a chapter and verse"
+          >
+            <div class="reader-navigation__field">
+              <label class="reader-navigation__label" for="reference-jump-chapter">Chapter</label>
+              <input
+                id="reference-jump-chapter"
+                name="chapter"
+                class="reader-navigation__input"
+                type="number"
+                min="1"
+                inputmode="numeric"
+                pattern="\\d*"
+                autocomplete="off"
+                disabled
+              />
+            </div>
+            <div class="reader-navigation__field">
+              <label class="reader-navigation__label" for="reference-jump-verse">Verse</label>
+              <input
+                id="reference-jump-verse"
+                name="verse"
+                class="reader-navigation__input"
+                type="number"
+                min="1"
+                inputmode="numeric"
+                pattern="\\d*"
+                autocomplete="off"
+                disabled
+              />
+            </div>
+            <button
+              id="reference-jump-submit"
+              class="reader-navigation__button"
+              type="submit"
+              disabled
+            >
+              Go
+            </button>
+          </form>
+          <p class="reader-navigation__hint" id="reference-jump-hint">
+            Jump controls will be enabled after the text loads.
+          </p>
+        </div>
       </div>
     </header>
     <main class="app-shell" aria-live="polite">

--- a/viewer/styles/main.css
+++ b/viewer/styles/main.css
@@ -82,6 +82,97 @@ body {
   box-shadow: 0 6px 18px rgba(35, 31, 32, 0.08);
 }
 
+.reader-navigation {
+  margin: 1.5rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 28rem;
+}
+
+.reader-navigation__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.reader-navigation__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 6.5rem;
+  flex: 1 1 7rem;
+}
+
+.reader-navigation__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+}
+
+.reader-navigation__input {
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: var(--card-bg);
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-family: inherit;
+  box-shadow: 0 4px 14px rgba(35, 31, 32, 0.06);
+}
+
+.reader-navigation__input:focus {
+  outline: 2px solid rgba(150, 112, 91, 0.35);
+  outline-offset: 2px;
+}
+
+.reader-navigation__input:disabled {
+  background: rgba(150, 112, 91, 0.08);
+  color: var(--text-muted);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.reader-navigation__button {
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--accent);
+  color: #ffffff;
+  font-size: 0.92rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 600;
+  font-family: inherit;
+  box-shadow: 0 10px 24px rgba(150, 112, 91, 0.28);
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.reader-navigation__button:disabled {
+  background: rgba(150, 112, 91, 0.3);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.reader-navigation__button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 30px rgba(150, 112, 91, 0.35);
+}
+
+.reader-navigation__button:not(:disabled):focus {
+  outline: 2px solid rgba(150, 112, 91, 0.35);
+  outline-offset: 2px;
+}
+
+.reader-navigation__hint {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
 .book-picker-select:focus {
   outline: 2px solid rgba(150, 112, 91, 0.35);
   outline-offset: 2px;
@@ -164,6 +255,13 @@ body {
   background: var(--card-bg);
   border: 1px solid var(--border);
   box-shadow: 0 8px 16px rgba(35, 31, 32, 0.04);
+  scroll-margin-top: 7rem;
+}
+
+.verse[data-active="true"] {
+  border-color: rgba(150, 112, 91, 0.6);
+  box-shadow: 0 0 0 3px rgba(150, 112, 91, 0.16), 0 12px 24px rgba(35, 31, 32, 0.08);
+  background: linear-gradient(180deg, rgba(150, 112, 91, 0.08), rgba(255, 255, 255, 0));
 }
 
 .verse-ref {
@@ -195,6 +293,20 @@ body {
   .book-picker {
     margin-top: 1rem;
     max-width: none;
+  }
+
+  .reader-navigation {
+    margin-top: 1.25rem;
+    max-width: none;
+  }
+
+  .reader-navigation__form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .reader-navigation__field {
+    min-width: 100%;
   }
 
   .verse {


### PR DESCRIPTION
## Summary
- add a chapter/verse jump form to the viewer header so readers can request specific references
- extend the viewer state to expose `jumpToReference`, toggle the controls as data loads, and highlight the active verse
- cover the new navigation workflow with unit tests for success, failure, and form submission paths

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca5dcb0a8c8324912e68d8c18e86fc