### PR TITLE
Ensure navigation controls enable after text loads

### DIFF
--- a/plans/gospel-of-mark-plan.md
+++ b/plans/gospel-of-mark-plan.md
@@ -10,8 +10,8 @@
 - [x] Generate a manifest of available viewer JSON payloads as part of the build step.
 - [x] Add a UI control that surfaces the manifest and lets readers choose a book.
 - [x] Wire the loader to fetch the selected book, with loading/empty states for clarity.
-- [ ] Index chapter and verse boundaries so navigation controls know their targets.
-- [ ] Implement direct chapter/verse jump inputs backed by the index.
+- [x] Index chapter and verse boundaries so navigation controls know their targets.
+- [x] Implement direct chapter/verse jump inputs backed by the index.
 - [ ] Add next/previous navigation shortcuts and verify they sync with the main text view.
 
 ## 3. Clause-Level Overlay

--- a/viewer/js/__tests__/main.test.js
+++ b/viewer/js/__tests__/main.test.js
@@ -426,8 +426,11 @@ test("renderVerses toggles the reference jump controls", () => {
   assert.equal(referenceJumpForm.getAttribute("aria-disabled"), "true");
   assert.equal(referenceJumpForm.dataset.state, "disabled");
   assert.equal(referenceChapterInput.disabled, true);
+  assert.equal(referenceChapterInput.getAttribute("disabled"), "");
   assert.equal(referenceVerseInput.disabled, true);
+  assert.equal(referenceVerseInput.getAttribute("disabled"), "");
   assert.equal(referenceJumpSubmit.disabled, true);
+  assert.equal(referenceJumpSubmit.getAttribute("disabled"), "");
   assert.equal(referenceJumpHint.textContent, "Jump controls will be enabled after the text loads.");
 
   viewer.renderVerses([
@@ -438,8 +441,11 @@ test("renderVerses toggles the reference jump controls", () => {
   assert.equal(referenceJumpForm.getAttribute("aria-disabled"), "false");
   assert.equal(referenceJumpForm.dataset.state, "ready");
   assert.equal(referenceChapterInput.disabled, false);
+  assert.equal(referenceChapterInput.getAttribute("disabled"), null);
   assert.equal(referenceVerseInput.disabled, false);
+  assert.equal(referenceVerseInput.getAttribute("disabled"), null);
   assert.equal(referenceJumpSubmit.disabled, false);
+  assert.equal(referenceJumpSubmit.getAttribute("disabled"), null);
   assert.equal(referenceChapterInput.value, "");
   assert.equal(referenceVerseInput.value, "");
   assert.equal(
@@ -452,8 +458,11 @@ test("renderVerses toggles the reference jump controls", () => {
   assert.equal(referenceJumpForm.getAttribute("aria-disabled"), "true");
   assert.equal(referenceJumpForm.dataset.state, "disabled");
   assert.equal(referenceChapterInput.disabled, true);
+  assert.equal(referenceChapterInput.getAttribute("disabled"), "");
   assert.equal(referenceVerseInput.disabled, true);
+  assert.equal(referenceVerseInput.getAttribute("disabled"), "");
   assert.equal(referenceJumpSubmit.disabled, true);
+  assert.equal(referenceJumpSubmit.getAttribute("disabled"), "");
   assert.equal(referenceJumpHint.textContent, "Jump controls will be enabled after the text loads.");
 });
 

--- a/viewer/js/main.js
+++ b/viewer/js/main.js
@@ -248,6 +248,29 @@
         : "Jump controls will be enabled after the text loads.";
     }
 
+    function setElementDisabledState(element, shouldDisable) {
+      if (!element) {
+        return;
+      }
+
+      const resolvedDisabled = !!shouldDisable;
+
+      if ("disabled" in element) {
+        element.disabled = resolvedDisabled;
+      }
+
+      const hasAttributeControls =
+        typeof element.setAttribute === "function" && typeof element.removeAttribute === "function";
+
+      if (hasAttributeControls) {
+        if (resolvedDisabled) {
+          element.setAttribute("disabled", "");
+        } else {
+          element.removeAttribute("disabled");
+        }
+      }
+    }
+
     function setReferenceControlsEnabled(nextEnabled) {
       const resolved = !!nextEnabled;
       viewerState.referenceControlsEnabled = resolved;
@@ -257,17 +280,11 @@
         referenceJumpForm.setAttribute("aria-disabled", resolved ? "false" : "true");
       }
 
-      if (referenceChapterInput) {
-        referenceChapterInput.disabled = !resolved;
-      }
+      const shouldDisable = !resolved;
 
-      if (referenceVerseInput) {
-        referenceVerseInput.disabled = !resolved;
-      }
-
-      if (referenceJumpSubmit) {
-        referenceJumpSubmit.disabled = !resolved;
-      }
+      setElementDisabledState(referenceChapterInput, shouldDisable);
+      setElementDisabledState(referenceVerseInput, shouldDisable);
+      setElementDisabledState(referenceJumpSubmit, shouldDisable);
 
       updateReferenceHint(resolved);
     }
@@ -367,9 +384,7 @@
     resetReferenceInputs();
     setReferenceControlsEnabled(false);
 
-    if (selectorEl) {
-      selectorEl.disabled = true;
-    }
+    setElementDisabledState(selectorEl, true);
 
     function normalizeBookEntry(entry) {
       if (!entry || typeof entry !== "object") {
@@ -742,9 +757,7 @@
           ? overrideUrl.trim()
           : viewerState.manifestUrl;
 
-      if (selectorEl) {
-        selectorEl.disabled = true;
-      }
+      setElementDisabledState(selectorEl, true);
 
       try {
         if (!fetchFn) {
@@ -778,15 +791,13 @@
           normalizedBooks.find((book) => book.dataUrl === viewerState.dataUrl) || normalizedBooks[0];
 
         updateSelectorOptions(normalizedBooks, matchingBook.bookId);
-        selectorEl.disabled = false;
+        setElementDisabledState(selectorEl, false);
 
         await selectBook(matchingBook.bookId);
         return manifestData;
       } catch (error) {
         safeConsole.error(error);
-        if (selectorEl) {
-          selectorEl.disabled = true;
-        }
+        setElementDisabledState(selectorEl, true);
         return null;
       }
     }


### PR DESCRIPTION
## Summary
- ensure the viewer removes disabled attributes when text finishes loading so chapter and verse inputs become interactive across browsers
- extend the unit test to assert the disabled attribute is cleared when the controls are ready and restored when verses disappear
- update the Gospel of Mark plan to reflect that navigation indexing and jump controls are complete

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca61b6790c8324b7d1a053e22b584a