### PR TITLE
Preserve clause metadata when rebuilding manifest

### DIFF
--- a/scripts/build_viewer_data.py
+++ b/scripts/build_viewer_data.py
@@ -115,16 +115,25 @@ def update_manifest(manifest_path: Path, payload_path: Path, payload: dict[str, 
         new_entry["source_path"] = payload.get("source_path")
 
     filtered_books = []
+    merged_entry: dict[str, Any] = {}
     for entry in books:
         if not isinstance(entry, dict):
             continue
-        if (
+
+        matches_existing = (
             entry.get("book_id") == new_entry.get("book_id")
             or entry.get("data_path") == new_entry.get("data_path")
             or entry.get("data_url") == new_entry.get("data_url")
-        ):
+        )
+
+        if matches_existing:
+            merged_entry.update(entry)
             continue
+
         filtered_books.append(entry)
+
+    merged_entry.update(new_entry)
+    new_entry = merged_entry
 
     filtered_books.append(new_entry)
     filtered_books.sort(key=_manifest_sort_key)

--- a/tests/test_build_viewer_data.py
+++ b/tests/test_build_viewer_data.py
@@ -164,6 +164,9 @@ def test_manifest_updates_existing_entry(tmp_path: Path, sample_lines: list[str]
                         "display_name": "Legacy Mark",
                         "data_path": "mark.json",
                         "data_url": "data/mark.json",
+                        "clause_data_path": "mark.clauses.json",
+                        "clause_data_url": "data/mark.clauses.json",
+                        "custom_note": "preserve me",
                     },
                     {
                         "book_id": "acts",
@@ -201,6 +204,9 @@ def test_manifest_updates_existing_entry(tmp_path: Path, sample_lines: list[str]
     acts_entry = next(book for book in manifest["books"] if book.get("book_id") == "acts")
 
     assert mark_entry["display_name"] == "Κατὰ Μᾶρκον"
+    assert mark_entry["clause_data_path"] == "mark.clauses.json"
+    assert mark_entry["clause_data_url"] == "data/mark.clauses.json"
+    assert mark_entry["custom_note"] == "preserve me"
     assert acts_entry["data_path"] == "acts.json"
 
 


### PR DESCRIPTION
## Summary
- merge existing manifest entry metadata when rebuilding book payloads so optional clause data URLs persist
- extend the manifest update test to confirm clause overlay fields and other custom keys survive regeneration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb6fd377a88324acdad20664e3692c